### PR TITLE
update to use 0.2.0 aframe.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,8 @@
     <script src="js/app.js"></script>
     <script src="js/controllers.js"></script>
 
-    <script type="text/javascript" src="https://rawgit.com/aframevr/aframe/master/dist/aframe.min.js"></script>
+    <!--<script type="text/javascript" src="https://rawgit.com/aframevr/aframe/master/dist/aframe.min.js"></script>-->
+    <script type="text/javascript" src="https://aframe.io/releases/0.2.0/aframe.min.js"></script>
 
 </head>
 <body>


### PR DESCRIPTION
update link to use 0.2.0 aframe, not working with latest version of aframe.